### PR TITLE
Add playgama.com/blog

### DIFF
--- a/list.txt
+++ b/list.txt
@@ -143,3 +143,4 @@
 ||pupuweb.com^$doc
 ||dn.org^$doc
 ||grokipedia.com^$doc
+||playgama.com/blog^$doc


### PR DESCRIPTION
From https://playgama.com/blog/, there are 700 pages of articles all supposedly written this year.
Interestingly though, the main domain hosts browser games.