### PR TITLE
Add techbloat.com

### DIFF
--- a/list.txt
+++ b/list.txt
@@ -167,6 +167,7 @@
 ||gameslearningsociety.org^$doc
 ||psicologiainsiemelivorno.it^$doc
 ||homecleaningstuff.com^$doc
+||techbloat.com^$doc
 
 
 ! To PR makers: add above new, individual, entries


### PR DESCRIPTION
I think this one is pretty self-explanatory
https://www.techbloat.com/author/techbloat
<img width="1254" height="661" alt="image" src="https://github.com/user-attachments/assets/a1dc5e67-39e1-4f75-aa29-56c0b66d9bea" />

[About us](https://www.techbloat.com/about-us) page is completely empty.

[Contact us](https://www.techbloat.com/contact-us) has a gmail address.

And the [privacy policy](https://www.techbloat.com/privacy-policy) is literally just AI-generated sample text.
<img width="760" height="785" alt="image" src="https://github.com/user-attachments/assets/dc54dbbc-fceb-44bc-89ae-126338e9dae9" />

And the [articles](https://www.techbloat.com/embeddable-review.html) themselves have lots of affiliate links
<img width="776" height="762" alt="image" src="https://github.com/user-attachments/assets/a0b28147-bf53-4bb0-9517-0d93016e86b5" />
