### PR TITLE
Add geekchamp.com

### DIFF
--- a/list.txt
+++ b/list.txt
@@ -178,6 +178,7 @@
 ||medium.com/@stackarchitect^$doc
 ||comepulire.net^$doc
 ||qualcherisposta.it^$doc
+||geekchamp.com^$doc
 
 
 ! To PR makers: add above new, individual, entries


### PR DESCRIPTION
Some of their articles are clearly AI-generated, like [this one](https://geekchamp.com/uma-technology-explained/) (no images, no links, AI writing, etc.). While others (including all the ones in the homepage) are written by humans: https://geekchamp.com/boot-into-safe-mode-on-windows-11/.
Both say they're written by the same person, but the links point to different profiles
<img width="222" height="217" alt="image" src="https://github.com/user-attachments/assets/fd79c08d-e65b-479d-ba3a-4124bc206d17" />
<img width="203" height="216" alt="image" src="https://github.com/user-attachments/assets/f1c8afa2-2bcb-4974-b6d7-ac48f62af10b" />

The "geekchamp" [author](https://geekchamp.com/author/geekchamp/) supposedly has 0 articles, which clearly isn't true.

All in all, I think it's better to block this site since this info can be found in other places without having AI slop mixed in. This site is also related to others already on the list like umatechnology: https://yorkermedia.com/

Edit: other AI articles: https://geekchamp.com/improve-quality-and-reduce-input-lag-on-steam-link/
https://geekchamp.com/how-to-uninstall-any-android-app-with-adb-including-system-apps-and-bloatware/