### PR TITLE
.gitattributes: Specify .txt as AdBlock Filter List

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+*.txt linguist-language=AdBlock linguist-detectable


### PR DESCRIPTION
Create .gitattributes file to specify all .txt files are AdBlock Filter Lists. Adds syntax highlighting when viewing filter files, and lists AdBlock Filter List under languages in GitHub.

See https://github.com/github-linguist/linguist/blob/main/docs/overrides.md

Also done in EasyList: https://github.com/easylist/easylist/blob/master/.gitattributes