### PR TITLE
.gitattributes: Don't mark uBlacklist list as Adblock list

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,1 +1,1 @@
-*.txt linguist-language=AdBlock linguist-detectable
+list.txt linguist-language=AdBlock linguist-detectable


### PR DESCRIPTION
My previous commit, #35, mistakenly marked `ublacklist.txt` as an Adblock Filter List. This limits the scope to just `list.txt`.