### PR TITLE
Add biblia-viva.com

### DIFF
--- a/list.txt
+++ b/list.txt
@@ -204,6 +204,7 @@
 ||cleaney.com^$doc
 ||imigliore.com^$doc
 ||theoriginarchive.com^$doc
+||biblia-viva.com^$doc
 
 
 ! To PR makers: add above new, individual, entries


### PR DESCRIPTION
Articles don't contain external references or images. The only "author" is called "bibliavivacom" (the site's name) and it has published ~5k articles since April 2024 (https://biblia-viva.com/author/bibliavivacom/page/50/).

For example, https://biblia-viva.com/la-eucaristia-en-la-biblia/ is detected as AI by Scribbr and GPTZero. And I even found some articles in English even though it's a Spanish-speaking site, like https://biblia-viva.com/if-not-me-then-who-verse/ or https://biblia-viva.com/now-i-am-glad-i-sent-it/ (which includes AI-generated images).