### PR TITLE
Add entries related to westdary@gmail.com

### DIFF
--- a/list.txt
+++ b/list.txt
@@ -2723,3 +2723,7 @@
 ||www.gameshub.com^$doc
 ||revenuepass.com^$doc
 ||videogamer.com^$doc
+
+! westdary@gmail.com
+||dcinl.com^$doc
+||definicionwiki.com^$doc


### PR DESCRIPTION
These websites seem to generate articles from human prompts. For example, looking at this article: https://dcinl.com/plan-empresa-que-es-y-para-que-sirve-significado-y-ejemplos/
The title is:
> Plan Empresa que es y para que Sirve

It contains various writing errors, it should be written as:

> Plan de empresa: qué es y para qué sirve

So if the title has that many errors, one would expect the article to be written in a similar way. But the article itself is written perfectly. I wonder why...
<img width="1082" height="577" alt="image" src="https://github.com/user-attachments/assets/37aa10de-d06e-4f3f-bac9-28b095ffba00" />

All articles are like this. The same goes for this other site: https://definicionwiki.com/que-es-en-forma-sintetica-significado-y-ejemplos-ejemplos/

A single author has posted >20k articles in less than a year: https://dcinl.com/author/aruiz/page/2079/

They both have the same contact information in the privacy policy page:
<img width="432" height="225" alt="image" src="https://github.com/user-attachments/assets/95eb59ea-0a58-4419-902b-bddef9fa2bd0" />
