### PR TITLE
Add dotlinux.net

### DIFF
--- a/list.txt
+++ b/list.txt
@@ -208,6 +208,7 @@
 ||biblia-viva.com^$doc
 ||cursorrules.org^$doc
 ||ejemplo.com.ar^$doc
+||dotlinux.net^$doc
 
 
 ! To PR makers: add above new, individual, entries


### PR DESCRIPTION
https://www.dotlinux.net/blog/how-to-create-snapshots-on-linux/
"A comprehensive guide"

The article is detected as AI:
<img width="1110" height="599" alt="image" src="https://github.com/user-attachments/assets/7e603f65-753b-4c56-bafb-8ab43e20d2ce" />

https://www.dotlinux.net/blog/10-best-native-linux-games/
Doom (2016) does not have a native Linux port. See https://en.wikipedia.org/wiki/Doom_(2016_video_game), https://www.gamingonlinux.com/2025/04/doom-2016-gets-a-surprise-release-on-gog-with-a-big-discount/. And the "Vulkan Low Latency Mode" also seems to be hallucinated.
Divinity: Original Sin 2 also doesn't have a native Linux port. https://steamcommunity.com/app/435150/discussions/0/595136186401446542/
`https://www.linuxgamedatabase.com/` (mentioned in the "references" section) does not exist.

Adobe does not provide a .deb package for Acrobat Reader, like what https://www.dotlinux.net/blog/how-to-install-adobe-acrobat-reader-on-ubuntu-and-debian-linux/ claims.

More than 1k articles in just November 2025 https://www.dotlinux.net/tag/2025-11/128/, hundreds of them being published on the same day.