### PR TITLE
Add more Argentinian sites related to PR #9

### DIFF
--- a/list.txt
+++ b/list.txt
@@ -307,6 +307,13 @@
 ||vanessa-mae.com.ar^$doc
 ||viegener.com.ar^$doc
 ||ypfelcruce.com.ar^$doc
+||saludymovimiento.com.ar^$doc
+||broccolino.com.ar^$doc
+||green-life.com.ar^$doc
+||libreriafan.com.ar^$doc
+||radiotaxisyremises.com.ar^$doc
+||yogacongreso.com.ar^$doc
+||solaringenieria.com.ar^$doc
 
 ! https://github.com/alvi-se/ai-ublock-blacklist/pull/11
 ||abasstoriola.com^$doc


### PR DESCRIPTION
These are more domains of very similar AI generated sites with the same kind of LLM text, fake ratings and more. See https://github.com/alvi-se/ai-ublock-blacklist/pull/9

For example https://who.is/whois/saludymovimiento.com.ar
<img width="342" height="359" alt="image" src="https://github.com/user-attachments/assets/3eee9f36-6602-4a08-8f84-75e6f2f5bd73" />
